### PR TITLE
Rework auth

### DIFF
--- a/api/auth/accounts.js
+++ b/api/auth/accounts.js
@@ -1,5 +1,8 @@
 /**
  * Enumerated Class for Account Types
+ *
+ * None - should never be part of a permission set
+ * It is simply denoting that such a role does not exist.
  */
 export default class Accounts {
   static None = new Accounts("none");

--- a/api/auth/accounts.js
+++ b/api/auth/accounts.js
@@ -2,6 +2,7 @@
  * Enumerated Class for Account Types
  */
 export default class Accounts {
+  static None = new Accounts("none");
   static Author = new Accounts("author");
   static Editor = new Accounts("editor");
   static Photographer = new Accounts("photographer");
@@ -10,5 +11,29 @@ export default class Accounts {
 
   constructor(role) {
     this.role = role;
+  }
+
+  /**
+   * I know it seems redundant but having an
+   * Accounts Class will hopefully keep our
+   * middleware more organized
+   *
+   * @param {String} str
+   */
+  static toAccount(str) {
+    switch (str.toLowerCase()) {
+      case "author":
+        return this.Author;
+      case "editor":
+        return this.Editor;
+      case "photographer":
+        return this.Photographer;
+      case "developer":
+        return this.Developer;
+      case "admin":
+        return this.Admin;
+      default:
+        return this.None;
+    }
   }
 }

--- a/api/auth/accounts.js
+++ b/api/auth/accounts.js
@@ -1,0 +1,14 @@
+/**
+ * Enumerated Class for Account Types
+ */
+export default class Accounts {
+  static Author = new Accounts("author");
+  static Editor = new Accounts("editor");
+  static Photographer = new Accounts("photographer");
+  static Developer = new Accounts("developer");
+  static Admin = new Accounts("admin");
+
+  constructor(role) {
+    this.role = role;
+  }
+}

--- a/api/auth/authorization.js
+++ b/api/auth/authorization.js
@@ -1,122 +1,53 @@
 import dotenv from "dotenv";
 import jwt from "jsonwebtoken";
+import PermissionSet from "./permissions.js";
 
 /**
  * Authorize Class
- * 
+ *
  * This class authorizes requests to pages with restrictions.
  * The lowest to highest authorization is as follows:
  * 1. Author
  * 2. Editor
  * 3. Developer
  * 4. Admin
- * Each subsequent level can access everything the previous level can access. 
+ * Each subsequent level can access everything the previous level can access.
  */
 export default class Authorize {
-    /**
-     * token Method
-     * 
-     * If the user is logged in, this method will call the next
-     * http method in line. If not, this method will redirect the
-     * user to be logged in.
-     * 
-     * @param {*} req http request
-     * @param {*} res http response
-     * @param {*} next http method
-     * @param {*} role role to be authorized
-     */
-    static token(req, res, next, role) {
-        dotenv.config();
-        if(req.cookies.token) {
-            const payload = jwt.verify(req.cookies.token, process.env.TOKEN_KEY);
-            if(payload) {
-                const userPermissionLevel = Authorize.roleToLevel(payload.role);
-                const requestedPermissionLevel = Authorize.roleToLevel(role);
-                
-                if(userPermissionLevel >= requestedPermissionLevel) {
-                    req.user = payload;
-                    next();
-                } else {
-                    req.error = 4012;
-                    next();
-                }
-            } else {
-                req.error = 4013;
-                next();
-            }
+  /**
+   * auth Method
+   *
+   * If the user is logged in, this method will call the next
+   * http method in line. If not, this method will redirect the
+   * user to be logged in.
+   *
+   * @param {*} req http request
+   * @param {*} res http response
+   * @param {*} next http method
+   * @param {*} role role to be authorized
+   */
+  static auth(req, res, next, route) {
+    dotenv.config();
+    if (req.cookies.token) {
+      const payload = jwt.verify(req.cookies.token, process.env.TOKEN_KEY);
+      if (payload) {
+        const userPermissionLevel = Authorize.roleToLevel(payload.role);
+        const requestedPermissionLevel = Authorize.roleToLevel(role);
+
+        if (userPermissionLevel >= requestedPermissionLevel) {
+          req.user = payload;
+          next();
         } else {
-            req.error = 4011;
-            next();
+          req.error = 4012;
+          next();
         }
+      } else {
+        req.error = 4013;
+        next();
+      }
+    } else {
+      req.error = 4011;
+      next();
     }
-
-    /**
-     * roleToLevel Method
-     * 
-     * This method takes in a user role, and returns its level.
-     * 
-     * @param {*} role 
-     * @returns integer - level associated with the role
-     */
-    static roleToLevel(role) {
-        switch(role) {
-            case "Author": return 1;
-            case "Editor": return 2;
-            case "Developer": return 3;
-            case "Admin": return 4;
-            default: return 0;
-        }
-    }
-
-    /**
-     * author Method
-     * 
-     * Authorizes permission for Author level accounts or higher.
-     * 
-     * @param {*} req http request
-     * @param {*} res http response
-     * @param {*} next next http middleware method
-     */
-    static author(req, res, next) {
-        return Authorize.token(req, res, next, "Author");
-    }
-
-    /**
-     * editor Method
-     * 
-     * Authorizes permission for Editor level accounts or higher.
-     * 
-     * @param {*} req http request
-     * @param {*} res http response
-     * @param {*} next next http middleware method
-     */
-    static editor(req, res, next) {
-        return Authorize.token(req, res, next, "Editor");
-    }
-
-    /**
-     * developer Method
-     * 
-     * Authorizes permission for Developer level accounts or higher.
-     * 
-     * @param {*} req http request
-     * @param {*} res http response
-     * @param {*} next next http middleware method
-     */
-    static developer(req, res, next) {
-        return Authorize.token(req, res, next, "Developer");
-    }
-
-    /**
-     * admin Method
-     * 
-     * Authorizes permission for Admin level accounts.
-     * 
-     * @param {*} req http request
-     * @param {*} res http response
-     * @param {*} next next http middleware method
-     */
-    static admin(req, res, next) {
-        return Authorize.token(req, res, next, "Admin");
-    }
+  }
 }

--- a/api/auth/permissions.js
+++ b/api/auth/permissions.js
@@ -32,8 +32,8 @@ class Permission {
 export default class PermissionSet {
   static permissions = [
     new Permission("GET profile", [Acc.Author, Acc.Editor, Acc.Photographer, Acc.Developer, Acc.Admin]),
-    new Permission("GET user-approvals", [Acc.Admin]),
-    new Permission("POST user-approvals", [Acc.Admin]),
+    new Permission("GET approve-user", [Acc.Admin]),
+    new Permission("POST approve-user", [Acc.Admin]),
   ];
 
   static check(permission, role) {

--- a/api/auth/permissions.js
+++ b/api/auth/permissions.js
@@ -1,0 +1,46 @@
+import Acc from "./accounts.js";
+
+/**
+ * Handles a single permission
+ */
+class Permission {
+  /**
+   *
+   * @param {String} permission permission to give
+   * @param {Array of Accounts} roles roles that have this permission
+   */
+  constructor(permission, roles) {
+    this.permission = permission;
+    this.roles = roles;
+  }
+
+  /**
+   * Checks if the given role has the given permission
+   *
+   * @param {String} permission
+   * @param {Array of Accounts} role
+   * @returns {Boolean}
+   */
+  check(permission, role) {
+    return this.permission === permission ? this.roles.includes(role) : false;
+  }
+}
+
+/**
+ * Handles the set of permissions
+ */
+export default class PermissionSet {
+  static permissions = [
+    new Permission("GET profile", [Acc.Author, Acc.Editor, Acc.Photographer, Acc.Developer, Acc.Admin]),
+    new Permission("GET user-approvals", [Acc.Admin]),
+    new Permission("POST user-approvals", [Acc.Admin]),
+  ];
+
+  static check(permission, role) {
+    let output = false;
+    for (const p of PermissionSet.permissions) {
+      output = output || p.check(permission, role);
+    }
+    return output;
+  }
+}

--- a/api/auth/permissions.js
+++ b/api/auth/permissions.js
@@ -36,6 +36,13 @@ export default class PermissionSet {
     new Permission("POST approve-user", [Acc.Admin]),
   ];
 
+  /**
+   * Checks if the given role has the given permission
+   *
+   * @param {String} permission
+   * @param {Accounts} role
+   * @returns {Boolean}
+   */
   static check(permission, role) {
     let output = false;
     for (const p of PermissionSet.permissions) {

--- a/api/controllers/routes.controller.js
+++ b/api/controllers/routes.controller.js
@@ -1,45 +1,46 @@
+import UsersAccessor from "../database_accessor/users.accessor.js";
+import Authorize from "../auth/authorization.js";
 /**
  * This file controlls routes that require functionality.
  */
 
 export default class RoutesController {
-    static getLogin(req, res) {
-        if(req.cookies.token) {
-            res.redirect('/profile');
-        } else {
-            res.render('login', {error: req.cookies.error});
-        }
+  static getLogin(req, res) {
+    if (req.cookies.token) {
+      res.redirect("/profile");
+    } else {
+      res.render("login", { error: req.cookies.error });
     }
+  }
 
-    static getError(req, res, next) {
-            //if the user requests the error page and an error doesn't exist, redirect to main
-        if(req.cookies.error) {
-            res.render('error', {error: req.cookies.error});
-        } else {
-            res.redirect('/');
-        }
+  static getError(req, res, next) {
+    //if the user requests the error page and an error doesn't exist, redirect to main
+    if (req.cookies.error) {
+      res.render("error", { error: req.cookies.error });
+    } else {
+      res.redirect("/");
     }
+  }
 
-    static getProfile(req, res, next) {
-        if(!req.error) {
-            const user = req.user;
-            res.render('profile',
-            {
-                name: user.username,
-                role: user.role,
-                year: user.information.year,
-                major: user.information.major,
-                bio: user.information.bio,
-            });
-        } else {
-            next();
-        }
+  static async getProfile(req, res, next) {
+    if (!req.error) {
+      const user = await UsersAccessor.getRegisteredByUsername(Authorize.getUsername(req));
+      console.log(user);
+      res.render("profile", {
+        name: user.username,
+        role: user.role,
+        year: user.information.year,
+        major: user.information.major,
+        bio: user.information.bio,
+      });
+    } else {
+      next();
     }
+  }
 
-    static getLogout(req, res) {
-        res.clearCookie('token');
-        res.redirect('/');
-        console.log("Signed out");
-    }
-
+  static getLogout(req, res) {
+    res.clearCookie("token");
+    res.redirect("/");
+    console.log("Signed out");
+  }
 }

--- a/api/controllers/users.controller.js
+++ b/api/controllers/users.controller.js
@@ -6,111 +6,116 @@ import jwt from "jsonwebtoken"; // import jwt to sign tokens
 
 /**
  * UsersCTRL Class
- * 
+ *
  * This class controls the behaviour of any web request
  * related to Users.
  */
 export default class UsersCTRL {
-    /**
-     * apiPostLogin Method
-     * 
-     * This method checks whether or not the request
-     * to sign in is valid. Utilizes the getRegisteredByUsername
-     * UserAccessor method to accomplish this.
-     * 
-     * @param {*} req web request object
-     * @param {*} res web response
-     */
-    static async apiPostLogin(req, res, next) {
-        try {
-            if(!req.cookies.token) {
-                // check if the user is registered
-                const user = await UsersAccessor.getRegisteredByUsername(
-                    req.body.username
-                );
-                if (user) {
-                    //check if password matches
-                    const result = await bcrypt.compare(
-                        req.body.password,
-                        user.password
-                    );
-                    if (result) {
-                        // sign token and send it in response
-                        const token = jwt.sign(
-                            {
-                                username: user.username,
-                                role: user.role,
-                                information: user.information
-                            },
-                            process.env.TOKEN_KEY
-                        );
+  /**
+   * apiPostLogin Method
+   *
+   * This method checks whether or not the request
+   * to sign in is valid. Utilizes the getRegisteredByUsername
+   * UserAccessor method to accomplish this.
+   *
+   * @param {*} req web request object
+   * @param {*} res web response
+   */
+  static async apiPostLogin(req, res, next) {
+    try {
+      if (!req.cookies.token) {
+        // check if the user is registered
+        const user = await UsersAccessor.getRegisteredByUsername(
+          req.body.username
+        );
+        if (user) {
+          //check if password matches
+          const result = await bcrypt.compare(req.body.password, user.password);
+          if (result) {
+            // sign token and send it in response
+            const token = jwt.sign(
+              {
+                username: user.username,
+                role: user.role,
+              },
+              process.env.TOKEN_KEY
+            );
 
-                        //Users are logged in for 1 hour
-                        res.cookie('token', token, {httpOnly: true, maxAge: 60 * 60 * 1000});
-                        res.redirect('/profile');
-                    } else {
-                        req.error = 4002;
-                        return next();
-                    }
-                } else {
-                    //check if the user is unregistered                 
-                    const unregistered = await UsersAccessor.getUnregisteredByUsername(req.body.username);
-                    if(unregistered) {
-                        req.error = 4005;
-                        return next();
-                    } else {
-                        //doesn't exist
-                        req.error = 4001;
-                        return next();
-                    }
-                }
-            } else {
-                req.error = 4003;
-                return next();
-            }
-        } catch (error) {
-            req.error = 4000;
+            //Users are logged in for 1 hour
+            res.cookie("token", token, {
+              httpOnly: true,
+              maxAge: 60 * 60 * 1000,
+            });
+            res.redirect("/profile");
+          } else {
+            req.error = 4002;
             return next();
-        }
-    }
-
-    /**
-     * apiPostSignUp Method
-     * 
-     * This method adds a new user to the unregistered user
-     * collection in the user database. It accomplishes this
-     * by calling the user.accessor.js file and creating a new
-     * user with the existing req data.
-     * 
-     * @param {*} req web request information for signup
-     * @param {*} res weh response object
-     */
-    static async apiPostSignUp(req, res, next) {
-        try {
-            // hash the password
-            req.body.password = await bcrypt.hash(req.body.password, 10);
-            
-            // make sure nested data is structured properly
-            req.body.information = {
-                year: req.body.year,
-                major: req.body.major,
-                bio: req.body.bio,
-                image: req.body.image,
-            }
-
-            const registered = await UsersAccessor.getRegisteredByUsername(req.body.username);
-            const unregistered = await UsersAccessor.getUnregisteredByUsername(req.body.username);
-            
-            if(!registered && !unregistered) {
-                await UsersAccessor.createUser(req.body);
-                res.redirect('/login');
-            } else {
-                req.error = 4004;
-                next();
-            }  
-        } catch (error) {
-            req.error = 4000;
+          }
+        } else {
+          //check if the user is unregistered
+          const unregistered = await UsersAccessor.getUnregisteredByUsername(
+            req.body.username
+          );
+          if (unregistered) {
+            req.error = 4005;
             return next();
+          } else {
+            //doesn't exist
+            req.error = 4001;
+            return next();
+          }
         }
+      } else {
+        req.error = 4003;
+        return next();
+      }
+    } catch (error) {
+      req.error = 4000;
+      return next();
     }
+  }
+
+  /**
+   * apiPostSignUp Method
+   *
+   * This method adds a new user to the unregistered user
+   * collection in the user database. It accomplishes this
+   * by calling the user.accessor.js file and creating a new
+   * user with the existing req data.
+   *
+   * @param {*} req web request information for signup
+   * @param {*} res weh response object
+   */
+  static async apiPostSignUp(req, res, next) {
+    try {
+      // hash the password
+      req.body.password = await bcrypt.hash(req.body.password, 10);
+
+      // make sure nested data is structured properly
+      req.body.information = {
+        year: req.body.year,
+        major: req.body.major,
+        bio: req.body.bio,
+        image: req.body.image,
+      };
+
+      const registered = await UsersAccessor.getRegisteredByUsername(
+        req.body.username
+      );
+      const unregistered = await UsersAccessor.getUnregisteredByUsername(
+        req.body.username
+      );
+
+      if (!registered && !unregistered) {
+        await UsersAccessor.createUser(req.body);
+        res.redirect("/login");
+      } else {
+        req.error = 4004;
+        next();
+      }
+    } catch (error) {
+      req.error = 4000;
+      return next();
+    }
+  }
 }

--- a/api/routes/pages.route.js
+++ b/api/routes/pages.route.js
@@ -1,9 +1,9 @@
-import express from 'express'
-import path from 'path'
-import UserCTRL from '../controllers/users.controller.js';
-import bodyParser from 'body-parser';
+import express from "express";
+import path from "path";
+import UserCTRL from "../controllers/users.controller.js";
+import bodyParser from "body-parser";
 import Authorize from "../auth/authorization.js";
-import catchError from '../routes/error.route.js';
+import catchError from "../routes/error.route.js";
 import RoutesController from "../controllers/routes.controller.js";
 import AdminController from "../controllers/admin.controller.js";
 
@@ -18,54 +18,61 @@ router.use(bodyParser.urlencoded({ extended: false }));
  */
 
 /* Default Page Router */
-router.route('/').get((req, res) => {
-    res.sendFile(path.resolve() + '/public/html/index.html');
-})
+router.route("/").get((req, res) => {
+  res.sendFile(path.resolve() + "/public/html/index.html");
+});
 
 /* Authors HTML Router */
-router.route('/authors').get((req, res) => {
-    res.sendFile(path.resolve() + '/public/html/authors.html');
-})
+router.route("/authors").get((req, res) => {
+  res.sendFile(path.resolve() + "/public/html/authors.html");
+});
 
 /* Eboard Page Router */
-router.route('/eboard').get((req, res) => {
-    res.sendFile(path.resolve() + '/public/html/eboard.html');
-})
+router.route("/eboard").get((req, res) => {
+  res.sendFile(path.resolve() + "/public/html/eboard.html");
+});
 
 /* Main CSS Router */
-router.route('/public/css/main.css').get((req, res) => {
-    res.sendFile(path.resolve() + 'public/css/main.css')
-})
+router.route("/public/css/main.css").get((req, res) => {
+  res.sendFile(path.resolve() + "public/css/main.css");
+});
 
 /* CSS Themes Router */
-router.route('/public/css/themes/:themeName.css').get((req, res) => {
-    res.sendFile(path.resolve() + `public/css/themes/${req.params.themeName}.css`);
-})
+router.route("/public/css/themes/:themeName.css").get((req, res) => {
+  res.sendFile(
+    path.resolve() + `public/css/themes/${req.params.themeName}.css`
+  );
+});
 
 /* Sign Up Page Router */
-router.route('/signup')
-.get((req, res) => {
-    res.sendFile(path.resolve() + '/public/html/signup.html');
-})
-.post(UserCTRL.apiPostSignUp, catchError);
+router
+  .route("/signup")
+  .get((req, res) => {
+    res.sendFile(path.resolve() + "/public/html/signup.html");
+  })
+  .post(UserCTRL.apiPostSignUp, catchError);
 
 /* Login Page Router */
-router.route('/login')
-.get(RoutesController.getLogin)
-.post(UserCTRL.apiPostLogin, catchError);
+router
+  .route("/login")
+  .get(RoutesController.getLogin)
+  .post(UserCTRL.apiPostLogin, catchError);
 
 /* Error Page Router */
-router.route('/error').get(RoutesController.getError);
+router.route("/error").get(RoutesController.getError);
 
 /* Logout Router */
-router.route('/logout').get(RoutesController.getLogout);
+router.route("/logout").get(RoutesController.getLogout);
 
 /* Profile Router */
-router.route('/profile').get(Authorize.author, RoutesController.getProfile, catchError);
+router
+  .route("/profile")
+  .get(Authorize.author, RoutesController.getProfile, catchError);
 
 /* New User Approval Router */
-router.route('/approve-user')
-.get(Authorize.admin, AdminController.getUserApprovals, catchError)
-.post(Authorize.admin, AdminController.postUserApprovals, catchError);
+router
+  .route("/approve-user")
+  .get(Authorize.admin, AdminController.getUserApprovals, catchError)
+  .post(Authorize.admin, AdminController.postUserApprovals, catchError);
 
 export default router;

--- a/api/routes/pages.route.js
+++ b/api/routes/pages.route.js
@@ -39,9 +39,7 @@ router.route("/public/css/main.css").get((req, res) => {
 
 /* CSS Themes Router */
 router.route("/public/css/themes/:themeName.css").get((req, res) => {
-  res.sendFile(
-    path.resolve() + `public/css/themes/${req.params.themeName}.css`
-  );
+  res.sendFile(path.resolve() + `public/css/themes/${req.params.themeName}.css`);
 });
 
 /* Sign Up Page Router */
@@ -53,10 +51,7 @@ router
   .post(UserCTRL.apiPostSignUp, catchError);
 
 /* Login Page Router */
-router
-  .route("/login")
-  .get(RoutesController.getLogin)
-  .post(UserCTRL.apiPostLogin, catchError);
+router.route("/login").get(RoutesController.getLogin).post(UserCTRL.apiPostLogin, catchError);
 
 /* Error Page Router */
 router.route("/error").get(RoutesController.getError);
@@ -65,14 +60,30 @@ router.route("/error").get(RoutesController.getError);
 router.route("/logout").get(RoutesController.getLogout);
 
 /* Profile Router */
-router
-  .route("/profile")
-  .get(Authorize.author, RoutesController.getProfile, catchError);
+router.route("/profile").get(
+  (req, res, next) => {
+    Authorize.auth(req, res, next, "GET profile");
+  },
+  RoutesController.getProfile,
+  catchError
+);
 
 /* New User Approval Router */
 router
   .route("/approve-user")
-  .get(Authorize.admin, AdminController.getUserApprovals, catchError)
-  .post(Authorize.admin, AdminController.postUserApprovals, catchError);
+  .get(
+    (req, res, next) => {
+      Authorize.auth(req, res, next, "GET approve-user");
+    },
+    AdminController.getUserApprovals,
+    catchError
+  )
+  .post(
+    (req, res, next) => {
+      Authorize.auth(req, res, next, "POST approve-user");
+    },
+    AdminController.postUserApprovals,
+    catchError
+  );
 
 export default router;


### PR DESCRIPTION
Auth has been reworked. (But not error handling yet)

Now, to add a new route that checks permissions, you need to add what type of account allowed to access that route. This is done in the permissions.js page. 

The middleware functions need to be added a little more strangely, to account for this. The first auth middleware function should be a callback with the req res and next function as parameters, runs the Auth function with the name of the route.

Closes #54.