### PR TITLE
Profile endpoints

### DIFF
--- a/api/api_models/base_model.js
+++ b/api/api_models/base_model.js
@@ -1,4 +1,4 @@
-import { ErrorInternalAPIModelFieldValidation } from "../error/internal_errors";
+import { ErrorInternalAPIModelFieldValidation } from "../error/internal_errors.js";
 import { ErrorInternalAPIModelValidation } from "../error/internal_errors.js";
 
 // Delegated Atomic Types

--- a/api/app.js
+++ b/api/app.js
@@ -3,6 +3,7 @@ import cors from "cors";
 import helmet from "helmet";
 import pagesRouter from "./routes/public.pages.route.js";
 import articlesRouter from "./routes/articles.route.js";
+import usersRouter from "./routes/users.route.js";
 import internalRouter from "./routes/internal.pages.route.js";
 import morgan from "morgan";
 import bodyParser from "body-parser";
@@ -30,5 +31,6 @@ app.use("/public", express.static(process.cwd() + "/public"));
 app.use("/", pagesRouter);
 app.use("/internal", internalRouter);
 app.use("/articles", articlesRouter);
+app.use("/users", usersRouter);
 
 export default app;

--- a/api/controllers/public.pages.controller.js
+++ b/api/controllers/public.pages.controller.js
@@ -2,6 +2,7 @@ import UsersAccessor from "../database_accessor/users.accessor.js";
 import Authorize from "../auth/authorization.js";
 import Errors from "../error/errors.js";
 import handleError from "../error/error.handler.js";
+import { UserPublicResponse, UserResponse } from "../api_models/user.js";
 
 /**
  * This file controls routes from the public pages routes file.
@@ -10,7 +11,7 @@ import handleError from "../error/error.handler.js";
 export default class PublicPagesController {
   static getLogin(req, res) {
     if (req.cookies.token) {
-      res.redirect("/profile");
+      res.redirect("/my-profile");
     } else {
       res.render("login", { error: req.cookies.error });
     }
@@ -25,25 +26,59 @@ export default class PublicPagesController {
     }
   }
 
-  static async getProfile(req, res, next) {
+  /**
+   * getMyProfile Method
+   *
+   * This method retrieves the profile of the logged-in user.
+   *
+   * @param {HTTP REQ} req web request object
+   * @param {HTTP RES} res web response object
+   * @param {function} next middleware function
+   */
+  static async getMyProfile(req, res, next) {
     try {
-      const user = await UsersAccessor.getRegisteredByUsername(Authorize.getUsername(req));
-      console.log(user);
-      res.render("profile", {
-        name: user.username,
-        role: user.role,
-        year: user.information.year,
-        major: user.information.major,
-        bio: user.information.bio,
-      });
+      const username = Authorize.getUsername(req);
+      const user = await UsersAccessor.getUserByUsername(username);
+
+      if (!user) {
+        return handleError(res, Errors[404].NotFound);
+      }
+
+      const userProfile = new UserResponse(user);
+      res.json(userProfile);
     } catch (e) {
+      return handleError(res, Errors[500].DataGET);
+    }
+  }
+
+  /**
+   * getPublicProfile Method
+   *
+   * This method retrieves the public profile of a user by their username.
+   *
+   * @param {HTTP REQ} req web request object
+   * @param {HTTP RES} res web response object
+   * @param {function} next middleware function
+   */
+  static async getPublicProfile(req, res, next) {
+    try {
+      const username = req.params.username;
+      const user = await UsersAccessor.getUserByUsername(username);
+
+      if (!user) {
+        return handleError(res, Errors[404].NotFound);
+      }
+
+      const publicUser = new UserPublicResponse(user);
+      res.json(publicUser);
+    } catch(e) {
       return handleError(res, Errors[500].DataGET);
     }
   }
 
   static async getEditProfile(req, res, next) {
     try {
-      const user = await UsersAccessor.getRegisteredByUsername(Authorize.getUsername(req));
+      const user = await UsersAccessor.getUserByUsername(Authorize.getUsername(req));
 
       res.render("edit_profile", {
         name: user.username,
@@ -83,7 +118,7 @@ export default class PublicPagesController {
         return handleError(res, Errors[404].UserNotFound);
       }
 
-      res.redirect("/profile");
+      res.redirect("/my-profile");
     } catch (e) {
       console.log(e);
       return handleError(res, Errors[500].DataPUT);

--- a/api/controllers/users.controller.js
+++ b/api/controllers/users.controller.js
@@ -51,7 +51,7 @@ export default class UsersCTRL {
                 httpOnly: true,
                 maxAge: 60 * 60 * 1000,
               });
-              res.redirect("/internal/profile");
+              res.redirect("/internal/my-profile");
             } else {
               return handleError(res, Errors[400].Login.Deactivated);
             }

--- a/api/error/error.handler.js
+++ b/api/error/error.handler.js
@@ -21,7 +21,7 @@ const handleError = (res, error) => {
       break;
     case Errors[400].Login.LoggedIn:
       res.cookie("error", "Already logged in", { maxAge: 1000 });
-      res.redirect("/internal/profile");
+      res.redirect("/internal/my-profile");
       break;
     case Errors[400].Login.Username:
       res.cookie("error", "User does not exist", { maxAge: 1000 });

--- a/api/error/internal_errors.js
+++ b/api/error/internal_errors.js
@@ -23,7 +23,7 @@ export class ErrorInternalEnumValidation extends InternalError {
 }
 
 export class ErrorCannotInitializeAbstractClass extends InternalError {
-  constuctor(msg) {
+  constructor(msg) {
     super(msg);
   }
 }

--- a/api/routes/internal.pages.route.js
+++ b/api/routes/internal.pages.route.js
@@ -35,9 +35,9 @@ const router = express.Router();
 router.use(bodyParser.urlencoded({ extended: false }));
 
 /* Profile Router */
-router.route("/profile").get((req, res, next) => {
+router.route("/my-profile").get((req, res, next) => {
   Authorize.auth(req, res, next, "GET profile");
-}, PagesController.getProfile);
+}, PagesController.getMyProfile);
 
 /* Edit Profile Router */
 router
@@ -69,7 +69,7 @@ router
   }, NewArticlesCTRL.apiPostArticle);
 
 
-/* Deactivate Account Router From /profile Page */
+/* Deactivate Account Router From /my-profile Page */
 router
   .route("/deactivate-profile")
   .get((req, res, next) => {
@@ -80,7 +80,7 @@ router
   }, UserController.postDeactivateProfile);
  
 
-/* Delete Account Router From /profile Page */
+/* Delete Account Router From /my-profile Page */
 router
 .route("/delete-profile")
 .get((req, res, next) => {
@@ -89,6 +89,5 @@ router
 .post((req, res, next) => {
   Authorize.auth(req, res, next, "POST delete-profile");
 }, UserController.postDeleteProfile)
-
 
 export default router;

--- a/api/routes/users.route.js
+++ b/api/routes/users.route.js
@@ -1,0 +1,10 @@
+import express from "express";
+import UsersCTRL from "../controllers/users.controller.js";
+
+/* Controls Routing for Users */
+
+const router = express.Router();
+
+router.route("/profile/:username").get(UsersCTRL.getPublicProfile);
+
+export default router;

--- a/public/js/edit_profile.js
+++ b/public/js/edit_profile.js
@@ -27,7 +27,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 throw new Error('Failed to update profile');
             }
 
-            window.location.href = '/profile';
+            window.location.href = '/my-profile';
 
         } catch (error) {
             console.error(error.message);

--- a/views/deactivate-profile.ejs
+++ b/views/deactivate-profile.ejs
@@ -13,6 +13,6 @@
         <form method="POST" action="/internal/deactivate-profile">
             <input type="submit" />
         </form>
-        <a href="/internal/profile">click to cancel deactivation</a>
+        <a href="/internal/my-profile">click to cancel deactivation</a>
     </body>
 </html>

--- a/views/delete-profile.ejs
+++ b/views/delete-profile.ejs
@@ -13,6 +13,6 @@
         <form method="POST" action="/internal/delete-profile">
             <input type="submit" />
         </form>
-        <a href="/internal/profile">click to cancel deletion</a>
+        <a href="/internal/my-profile">click to cancel deletion</a>
     </body>
 </html>

--- a/views/edit_profile.ejs
+++ b/views/edit_profile.ejs
@@ -32,6 +32,6 @@
             <input type="submit" value="Submit">
         </form>
         <br />
-        <a href="/internal/profile">click to return</a>
+        <a href="/internal/my-profile">click to return</a>
     </body>
 </html> 


### PR DESCRIPTION
Added endpoints and some other fixes

## Pull Request

[comment]: <> (Put N/A if a section does not apply.)

### Brief Summary
Add the `/users/profile/:username` endpoint in a new `users.route.js` file, similar to the current setup for article endpoints

The `/internal/profile` endpoint already existed in `internal.pages.route.js`, so I renamed it to `/internal/my-profile` and the `getProfile` controller method to `getMyProfile`.

The `getMyProfile` 

Add a controller methods to each one.

Call the DB accessors that get users by username.

for the public profile endpoint, respond with a public user response.
for the internal endpoint, respond with the full UserResponse object.

res.json that

### Questions / Considerations for the Future
- 

### API Changes
- 

### Database Changes
- N/A

### New Tests
- N/A

[comment]: <> (Put the ticket # this PR closes)

Closes #171 
